### PR TITLE
fix: roles command not working if a user has a similar name to a joinable role

### DIFF
--- a/src/commands/User/roles.js
+++ b/src/commands/User/roles.js
@@ -10,7 +10,7 @@ module.exports = class extends Command {
 			aliases: ['roleme', 'team', 'squad', 'role'],
 			description: language => language.get('COMMAND_ROLES_DESCRIPTION'),
 			extendedHelp: language => language.get('COMMAND_ROLES_EXTENDED'),
-			usage: '<list|add|remove|join|leave> [target:membername] [roleName:...string]',
+			usage: '<list|add|remove|join|leave> [target:member] [roleName:...string]',
 			usageDelim: ' ',
 			subcommands: true
 		});


### PR DESCRIPTION
Fixed by removing `membername` functionality from roles command.

fixes #40 