### PR TITLE
feat: capture error logs for global log

### DIFF
--- a/src/events/rtbyteCommandError.js
+++ b/src/events/rtbyteCommandError.js
@@ -1,0 +1,30 @@
+const { Event } = require('klasa');
+const { MessageEmbed } = require('discord.js');
+
+module.exports = class extends Event {
+
+	constructor(...args) {
+		super(...args, { event: 'commandError' });
+	}
+
+	async run(message, command, params, error) {
+		if (this.client.settings.get('logs.commandError')) await this.commandErrorLog(message, command, params, error);
+		return message.reject(message.language.get('COMMAND_ERROR'));
+	}
+
+	async commandErrorLog(message, command, params, error) {
+		const globalLog = await this.client.channels.get(this.client.settings.get('channels.globalLog'));
+		const embed = new MessageEmbed()
+			.setAuthor(this.client.user.username, this.client.user.displayAvatarURL())
+			.setColor(this.client.settings.get('colors.red'))
+			.addField(globalLog.guild.language.get('COMMAND'), message.content)
+			.addField(globalLog.guild.language.get('GLOBAL_LOG_ERROR_EXECUTEDIN'), message.guild ? `\`${message.guild.name} (${message.guild.id})\`` : `\`${message.author.tag} (${message.author.id})\``)
+			.addField(globalLog.guild.language.get('GLOBAL_LOG_ERROR_ORIGIN'), `\`\`\`${command.path}\`\`\``)
+			.addField(globalLog.guild.language.get('GLOBAL_LOG_ERROR_ERRORSTACK'), `\`\`\`${error ? error.stack ? error.stack : error : 'Unknown error'}\`\`\``)
+			.setTimestamp()
+			.setFooter(globalLog.guild.language.get('GLOBAL_LOG_COMMANDERROR'));
+		if (globalLog) await globalLog.send('', { disableEveryone: true, embed: embed });
+		return;
+	}
+
+};

--- a/src/events/rtbyteEventError.js
+++ b/src/events/rtbyteEventError.js
@@ -1,0 +1,30 @@
+const { Event } = require('klasa');
+const { MessageEmbed } = require('discord.js');
+const errorEvents = ['rtbyteCommandError', 'rtbyteEventError', 'rtbyteFinalizerError', 'rtbyteMonitorError', 'rtbyteTaskError'];
+
+module.exports = class extends Event {
+
+	constructor(...args) {
+		super(...args, { event: 'eventError' });
+	}
+
+	async run(event, args, error) {
+		const guild = args[0].guild ? args[0].guild : args[0].message ? args[0].message.guild : args[0];
+		if (this.client.settings.get('logs.eventError') && !errorEvents.includes(event.name)) await this.eventErrorLog(event, args, error, guild);
+	}
+
+	async eventErrorLog(event, args, error, guild) {
+		const globalLog = await this.client.channels.get(this.client.settings.get('channels.globalLog'));
+		const embed = new MessageEmbed()
+			.setAuthor(this.client.user.username, this.client.user.displayAvatarURL())
+			.setColor(this.client.settings.get('colors.red'))
+			.addField(globalLog.guild.language.get('GLOBAL_LOG_ERROR_EXECUTEDIN'), `\`${guild.name} (${guild.id})\``)
+			.addField(globalLog.guild.language.get('GLOBAL_LOG_ERROR_ORIGIN'), `\`\`\`${event.path}\`\`\``)
+			.addField(globalLog.guild.language.get('GLOBAL_LOG_ERROR_ERRORSTACK'), `\`\`\`${error ? error.stack ? error.stack : error : 'Unknown error'}\`\`\``)
+			.setTimestamp()
+			.setFooter(globalLog.guild.language.get('GLOBAL_LOG_EVENTERROR'));
+		if (globalLog) await globalLog.send('', { disableEveryone: true, embed: embed });
+		return;
+	}
+
+};

--- a/src/events/rtbyteFinalizerError.js
+++ b/src/events/rtbyteFinalizerError.js
@@ -1,0 +1,29 @@
+const { Event } = require('klasa');
+const { MessageEmbed } = require('discord.js');
+
+module.exports = class extends Event {
+
+	constructor(...args) {
+		super(...args, { event: 'finalizerError' });
+	}
+
+	async run(message, command, response, timer, finalizer, error) {
+		if (this.client.settings.get('logs.finalizerError')) await this.finalizerErrorLog(message, command, response, timer, finalizer, error);
+	}
+
+	async finalizerErrorLog(message, command, response, timer, finalizer, error) {
+		const globalLog = await this.client.channels.get(this.client.settings.get('channels.globalLog'));
+		const embed = new MessageEmbed()
+			.setAuthor(this.client.user.username, this.client.user.displayAvatarURL())
+			.setColor(this.client.settings.get('colors.red'))
+			.addField(globalLog.guild.language.get('COMMAND'), message.content)
+			.addField(globalLog.guild.language.get('GLOBAL_LOG_ERROR_EXECUTEDIN'), message.guild ? `\`${message.guild.name} (${message.guild.id})\`` : `\`${message.author.tag} (${message.author.id})\``)
+			.addField(globalLog.guild.language.get('GLOBAL_LOG_ERROR_ORIGIN'), `\`\`\`${finalizer.path}\`\`\``)
+			.addField(globalLog.guild.language.get('GLOBAL_LOG_ERROR_ERRORSTACK'), `\`\`\`${error ? error.stack ? error.stack : error : 'Unknown error'}\`\`\``)
+			.setTimestamp()
+			.setFooter(globalLog.guild.language.get('GLOBAL_LOG_FINALIZERERROR'));
+		if (globalLog) await globalLog.send('', { disableEveryone: true, embed: embed });
+		return;
+	}
+
+};

--- a/src/events/rtbyteMonitorError.js
+++ b/src/events/rtbyteMonitorError.js
@@ -1,0 +1,28 @@
+const { Event } = require('klasa');
+const { MessageEmbed } = require('discord.js');
+
+module.exports = class extends Event {
+
+	constructor(...args) {
+		super(...args, { event: 'monitorError' });
+	}
+
+	async run(message, monitor, error) {
+		if (this.client.settings.get('logs.monitorError')) await this.monitorErrorLog(message, monitor, error);
+	}
+
+	async monitorErrorLog(message, monitor, error) {
+		const globalLog = await this.client.channels.get(this.client.settings.get('channels.globalLog'));
+		const embed = new MessageEmbed()
+			.setAuthor(this.client.user.username, this.client.user.displayAvatarURL())
+			.setColor(this.client.settings.get('colors.red'))
+			.addField(globalLog.guild.language.get('GLOBAL_LOG_ERROR_EXECUTEDIN'), message.guild ? `\`${message.guild.name} (${message.guild.id})\`` : `\`${message.author.tag} (${message.author.id})\``)
+			.addField(globalLog.guild.language.get('GLOBAL_LOG_ERROR_ORIGIN'), `\`\`\`${monitor.path}\`\`\``)
+			.addField(globalLog.guild.language.get('GLOBAL_LOG_ERROR_ERRORSTACK'), `\`\`\`${error ? error.stack ? error.stack : error : 'Unknown error'}\`\`\``)
+			.setTimestamp()
+			.setFooter(globalLog.guild.language.get('GLOBAL_LOG_MONITORERROR'));
+		if (globalLog) await globalLog.send('', { disableEveryone: true, embed: embed });
+		return;
+	}
+
+};

--- a/src/events/rtbyteTaskError.js
+++ b/src/events/rtbyteTaskError.js
@@ -1,0 +1,27 @@
+const { Event } = require('klasa');
+const { MessageEmbed } = require('discord.js');
+
+module.exports = class extends Event {
+
+	constructor(...args) {
+		super(...args, { event: 'taskError' });
+	}
+
+	async run(scheduledTask, task, error) {
+		if (this.client.settings.get('logs.taskError')) await this.eventErrorLog(scheduledTask, task, error);
+	}
+
+	async eventErrorLog(scheduledTask, task, error) {
+		const globalLog = await this.client.channels.get(this.client.settings.get('channels.globalLog'));
+		const embed = new MessageEmbed()
+			.setAuthor(this.client.user.username, this.client.user.displayAvatarURL())
+			.setColor(this.client.settings.get('colors.red'))
+			.addField(globalLog.guild.language.get('GLOBAL_LOG_ERROR_ORIGIN'), `\`\`\`${task.path}\`\`\``)
+			.addField(globalLog.guild.language.get('GLOBAL_LOG_ERROR_ERRORSTACK'), `\`\`\`${error ? error.stack ? error.stack : error : 'Unknown error'}\`\`\``)
+			.setTimestamp()
+			.setFooter(globalLog.guild.language.get('GLOBAL_LOG_TASKERROR'));
+		if (globalLog) await globalLog.send('', { disableEveryone: true, embed: embed });
+		return;
+	}
+
+};

--- a/src/languages/en-US.js
+++ b/src/languages/en-US.js
@@ -116,6 +116,7 @@ module.exports = class extends Language {
 			NOT_SET: 'Not set',
 			REGION: (region) => this.regions[region],
 			UNFETCHABLE_USER: 'Unfetchable user',
+			COMMAND: 'Command',
 
 
 			// Permission langs
@@ -238,6 +239,7 @@ module.exports = class extends Language {
 
 
 			// Command langs
+			COMMAND_ERROR: 'Sorry, it seems like the bot ran into an error when trying to execute this command. It has been reported to the developers.',
 			COMMAND_REQUESTED_BY: (msg) => `Requested by ${msg.author.tag}`,
 			COMMAND_BLACKLIST_DESCRIPTION: 'Blacklists or un-blacklists users and servers from the bot.',
 			COMMAND_BLACKLIST_SUCCESS: (usersAdded, usersRemoved, guildsAdded, guildsRemoved) => [
@@ -893,6 +895,7 @@ module.exports = class extends Language {
 			GUILD_LOG_WEBHOOKUPDATE_CHANNEL: 'Channel changed',
 			GUILD_LOG_WEBHOOKUPDATE_AVATAR: 'Icon changed',
 
+
 			// Global log langs
 			GLOBAL_LOG_GUILDCREATE: 'Bot added to server',
 			GLOBAL_LOG_GUILDDELETE: 'Bot removed from server',
@@ -901,6 +904,14 @@ module.exports = class extends Language {
 			GLOBAL_LOG_GUILDUNAVAILABLE: 'Server unavailable, likely due to a server outage',
 			GLOBAL_LOG_COMMANDRUN: 'Command ran',
 			GLOBAL_LOG_COMMANDRUN_DM: 'Command ran in DM',
+			GLOBAL_LOG_ERROR_EXECUTEDIN: 'Originating server',
+			GLOBAL_LOG_ERROR_ORIGIN: 'Originating file',
+			GLOBAL_LOG_ERROR_ERRORSTACK: 'Error stack',
+			GLOBAL_LOG_COMMANDERROR: 'Command error',
+			GLOBAL_LOG_EVENTERROR: 'Event error',
+			GLOBAL_LOG_FINALIZERERROR: 'Finalizer error',
+			GLOBAL_LOG_MONITORERROR: 'Monitor error',
+			GLOBAL_LOG_TASKERROR: 'Task error',
 
 
 			// Moderation action langs

--- a/src/lib/structures/schemas/defaultClientSchema.js
+++ b/src/lib/structures/schemas/defaultClientSchema.js
@@ -20,6 +20,11 @@ module.exports = KlasaClient.defaultClientSchema
 	.add('logs', folder => folder
 		.add('botReady', 'boolean', { default: true })
 		.add('commandRun', 'boolean', { default: true })
+		.add('commandError', 'boolean', { default: true })
+		.add('eventError', 'boolean', { default: true })
+		.add('finalizerError', 'boolean', { default: true })
+		.add('monitorError', 'boolean', { default: true })
+		.add('taskError', 'boolean', { default: true })
 		.add('guildCreate', 'boolean', { default: true })
 		.add('guildDelete', 'boolean', { default: true })
 		.add('guildUpdate', 'boolean', { default: true })


### PR DESCRIPTION
Adds error log reporting for the global log channel, letting us see when errors appear without monitoring the console. Tests have been made, and confirmed to be working.