### PR TITLE
Reworking constants

### DIFF
--- a/src/commands/Management/autoresponder.js
+++ b/src/commands/Management/autoresponder.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -18,8 +19,8 @@ module.exports = class extends Command {
 
 	async show(msg) {
 		// Fetch required emojis and assiociate true or false with the corresponding one.
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
 		const status = {
 			true: affirmEmoji,
 			false: rejectEmoji
@@ -35,7 +36,7 @@ module.exports = class extends Command {
 		// Build embed before sending.
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_AUTORESPONDER_SHOW_TITLE'), this.client.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.language.get('ENABLED'), autoresponderEnabled, true)
 			.addField(msg.language.get('COMMAND_AUTORESPONDER_SHOW_RESPONSES'), autoresponses)
 			.addField(msg.language.get('COMMAND_MANAGEMENT_SHOW_IGNORED'), autoresponderIgnoredChannels)

--- a/src/commands/Management/customcmds.js
+++ b/src/commands/Management/customcmds.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -17,8 +18,8 @@ module.exports = class extends Command {
 
 	async show(msg) {
 		// Fetch required emojis and assiociate true or false with the corresponding one.
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
 		const status = {
 			true: affirmEmoji,
 			false: rejectEmoji
@@ -31,7 +32,7 @@ module.exports = class extends Command {
 		// Build embed before sending.
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_CUSTOMCMDS_SHOW_TITLE'), this.client.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.language.get('ENABLED'), customCommandsEnabled, true)
 			.addField(msg.language.get('CUSTOM_COMMANDS'), customCommands)
 			.setThumbnail(msg.guild.iconURL(), 50, 50)

--- a/src/commands/Management/filters.js
+++ b/src/commands/Management/filters.js
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../../lib/util/constants');
 
 const enableDisableArr = ['blacklist', 'antiinvite', 'mentionspam', 'modbypass', 'deletion', 'blistchecknames'];
 const punishmentArr = ['mute', 'kick', 'softban', 'ban'];
@@ -22,8 +23,8 @@ module.exports = class extends Command {
 
 	async show(msg) {
 		// Fetch required emojis and assiociate true or false with the corresponding one.
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
 		const status = {
 			true: affirmEmoji,
 			false: rejectEmoji
@@ -55,7 +56,7 @@ module.exports = class extends Command {
 		// Build embed before sending.
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_FILTERS_SHOW_TITLE'), this.client.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.language.get('COMMAND_FILTERS_SHOW_MODBYPASS'), modBypass, true)
 			.addField(msg.language.get('COMMAND_FILTERS_SHOW_DELETION'), deletion, true)
 			.addField(msg.language.get('COMMAND_FILTERS_SHOW_WORDBLACKLIST'), wordBlacklistEnabled, true)

--- a/src/commands/Management/greetings.js
+++ b/src/commands/Management/greetings.js
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -17,8 +18,8 @@ module.exports = class extends Command {
 
 	async show(msg) {
 		// Fetch required emojis and assiociate true or false with the corresponding one.
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
 		const status = {
 			true: affirmEmoji,
 			false: rejectEmoji
@@ -35,7 +36,7 @@ module.exports = class extends Command {
 		// Build embed before sending.
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_GREETINGS_SHOW_TITLE'), this.client.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.language.get('COMMAND_GREETINGS_SHOW_WELCOME'), welcomeNewUsers, true)
 			.addField(msg.language.get('COMMAND_GREETINGS_SHOW_WELCOME_CHANNEL'), welcomeChannel, true)
 			.addField(msg.language.get('COMMAND_GREETINGS_SHOW_WELCOME_MESSAGE'), welcomeMessage)

--- a/src/commands/Management/logs.js
+++ b/src/commands/Management/logs.js
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
 const { Command, RichDisplay } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../../lib/util/constants');
 
 const enableDisableArr = ['cmdrun', 'msgdelete', 'msgedit', 'serverupdate',
 	'invitecreate', 'invitedelete', 'channelcreate', 'channeldelete',
@@ -42,7 +43,7 @@ module.exports = class extends Command {
 
 		const loadingEmbed = new MessageEmbed()
 			.setTitle(msg.language.get('COMMAND_LOGS_SHOW_LOADING'))
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.setThumbnail(msg.guild.iconURL(), 50, 50)
 			.setTimestamp();
 
@@ -315,13 +316,13 @@ module.exports = class extends Command {
 	}
 
 	async buildDisplay(msg) {
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
-		const arrowToLeftEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowToLeft'));
-		const arrowLeftEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowLeft'));
-		const arrowRightEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowRight'));
-		const arrowToRightEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowToRight'));
-		const listEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.list'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
+		const arrowToLeftEmoji = this.client.emojis.cache.get(Emojis.arrowToLeft);
+		const arrowLeftEmoji = this.client.emojis.cache.get(Emojis.arrowLeft);
+		const arrowRightEmoji = this.client.emojis.cache.get(Emojis.arrowRight);
+		const arrowToRightEmoji = this.client.emojis.cache.get(Emojis.arrowToRight);
+		const listEmoji = this.client.emojis.cache.get(Emojis.list);
 		const status = {
 			true: affirmEmoji,
 			false: rejectEmoji
@@ -363,7 +364,7 @@ module.exports = class extends Command {
 		const page1 = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_LOGS_SHOW_TITLE'), this.client.user.displayAvatarURL())
 			.setDescription(msg.language.get('COMMAND_MANAGEMENT_SHOW_DESCRIPTION'))
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.language.get('CHANNEL'), logChannel)
 			.addField(msg.language.get('COMMAND_LOGS_SHOW_COMMANDRUN'), commandRun, true)
 			.addField(msg.language.get('COMMAND_LOGS_SHOW_MESSAGEDELETE'), messageDelete, true)
@@ -387,7 +388,7 @@ module.exports = class extends Command {
 		const page2 = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_LOGS_SHOW_TITLE'), this.client.user.displayAvatarURL())
 			.setDescription(msg.language.get('COMMAND_MANAGEMENT_SHOW_DESCRIPTION'))
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.language.get('COMMAND_LOGS_SHOW_WEBHOOKCREATE'), webhookCreate, true)
 			.addField(msg.language.get('COMMAND_LOGS_SHOW_WEBHOOKDELETE'), webhookDelete, true)
 			.addField(msg.language.get('COMMAND_LOGS_SHOW_WEBHOOKUPDATE'), webhookUpdate, true)

--- a/src/commands/Management/moderation.js
+++ b/src/commands/Management/moderation.js
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../../lib/util/constants');
 
 const enableDisableArr = ['notify', 'purge', 'warn', 'mute', 'unmute',
 	'kick', 'softban', 'ban', 'unban', 'vckick', 'vcban', 'vcunban',
@@ -20,8 +21,8 @@ module.exports = class extends Command {
 	}
 
 	async show(msg) {
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
 		const status = {
 			true: affirmEmoji,
 			false: rejectEmoji
@@ -47,7 +48,7 @@ module.exports = class extends Command {
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_MODERATION_SHOW_TITLE'), this.client.user.displayAvatarURL())
 			.setDescription(msg.language.get('COMMAND_MANAGEMENT_SHOW_DESCRIPTION'))
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.language.get('COMMAND_MODERATION_SHOW_NOTIFYUSER'), notifyUser)
 			.addField(msg.language.get('COMMAND_MODERATION_SHOW_PURGE'), purge, true)
 			.addField(msg.language.get('COMMAND_MODERATION_SHOW_WARN'), warn, true)

--- a/src/commands/Management/pinboard.js
+++ b/src/commands/Management/pinboard.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -15,8 +16,8 @@ module.exports = class extends Command {
 	}
 
 	async show(msg) {
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
 		const status = {
 			true: affirmEmoji,
 			false: rejectEmoji
@@ -28,7 +29,7 @@ module.exports = class extends Command {
 
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_PINBOARD_SHOW_TITLE'), this.client.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.language.get('ENABLED'), pinboardEnabled, true)
 			.addField(msg.language.get('COMMAND_MANAGEMENT_SHOW_CHANNEL'), pinboardChannel, true)
 			.addField(msg.language.get('COMMAND_MANAGEMENT_SHOW_IGNORED'), pinboardIgnoredChannels)

--- a/src/commands/Management/settings.js
+++ b/src/commands/Management/settings.js
@@ -2,6 +2,7 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
 const moment = require('moment-timezone');
+const { Colors, Emojis } = require('../../lib/util/constants');
 
 const rolesArr = ['admin', 'mod', 'muted', 'vcbanned', 'joinable'];
 
@@ -20,8 +21,8 @@ module.exports = class extends Command {
 	}
 
 	async show(msg) {
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
 		const status = {
 			true: affirmEmoji,
 			false: rejectEmoji
@@ -48,7 +49,7 @@ module.exports = class extends Command {
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_SETTINGS_SHOW_TITLE'), this.client.user.displayAvatarURL())
 			.setDescription(msg.language.get('COMMAND_MANAGEMENT_SHOW_DESCRIPTION'))
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.language.get('COMMAND_SETTINGS_SHOW_PREFIX'), `\`${prefix}\``, true)
 			.addField(msg.language.get('COMMAND_SETTINGS_SHOW_LANGUAGE'), serverLanguage, true)
 			.addField(msg.language.get('COMMAND_SETTINGS_SHOW_MEASUREMENTUNITS'), measurementUnits, true)

--- a/src/commands/Management/starboard.js
+++ b/src/commands/Management/starboard.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -15,8 +16,8 @@ module.exports = class extends Command {
 	}
 
 	async show(msg) {
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
 		const status = {
 			true: affirmEmoji,
 			false: rejectEmoji
@@ -29,7 +30,7 @@ module.exports = class extends Command {
 
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_STARBOARD_SHOW_TITLE'), this.client.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.language.get('ENABLED'), starboardEnabled)
 			.addField(msg.language.get('COMMAND_MANAGEMENT_SHOW_THRESHOLD'), starboardThreshold, true)
 			.addField(msg.language.get('COMMAND_MANAGEMENT_SHOW_CHANNEL'), starboardChannel, true)

--- a/src/commands/Management/twitchnotifs.js
+++ b/src/commands/Management/twitchnotifs.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -16,8 +17,8 @@ module.exports = class extends Command {
 	}
 
 	async show(msg) {
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
 		const status = {
 			true: affirmEmoji,
 			false: rejectEmoji
@@ -31,7 +32,7 @@ module.exports = class extends Command {
 
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_TWITCHNOTIFS_SHOW_TITLE'), this.client.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.language.get('ENABLED'), twitchNotifsEnabled)
 			.addField(msg.language.get('COMMAND_TWITCHNOTIFS_SHOW_CHANNEL'), twitchNotifsChannel, true)
 			.addField(msg.language.get('COMMAND_TWITCHNOTIFS_SHOW_STREAMERS'), streamers)

--- a/src/commands/Moderator/channelinfo.js
+++ b/src/commands/Moderator/channelinfo.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../../lib/util/constants');
 const { momentThreshold, timezoneWithDate } = require('../../lib/util/util');
 const moment = require('moment-timezone');
 
@@ -19,15 +20,15 @@ module.exports = class extends Command {
 	}
 
 	async run(msg, [channelname = msg.channel]) {
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
 		const status = {
 			true: affirmEmoji,
 			false: rejectEmoji
 		};
 
 		const embed = new MessageEmbed()
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.guild.language.get('NAME'), channelname.type !== 'voice' && channelname.type !== 'category' ? channelname : channelname.name, true)
 			.addField(msg.guild.language.get('ID'), channelname.id, true)
 			.addField(msg.language.get('COMMAND_CHANNELINFO_TYPE'), msg.language.get('COMMAND_CHANNELINFO_TYPES', channelname), true)

--- a/src/commands/Moderator/modHistory.js
+++ b/src/commands/Moderator/modHistory.js
@@ -2,6 +2,7 @@
 const { Command, RichDisplay } = require('klasa');
 const { MessageEmbed } = require('discord.js');
 const { ModCase } = require('../../index');
+const { Colors, Emojis } = require('../../lib/util/constants');
 
 const timeout = 1000 * 60 * 3;
 
@@ -44,7 +45,7 @@ module.exports = class extends Command {
 
 			const loadingEmbed = new MessageEmbed()
 				.setTitle(msg.language.get('COMMAND_MODHISTORY_LOADING'))
-				.setColor(this.client.settings.get('colors.white'))
+				.setColor(Colors.white)
 				.setThumbnail(target.user.displayAvatarURL(), 50, 50)
 				.setTimestamp();
 
@@ -65,7 +66,7 @@ module.exports = class extends Command {
 
 			const loadingEmbed = new MessageEmbed()
 				.setTitle(msg.language.get('COMMAND_MODHISTORY_LOADING'))
-				.setColor(this.client.settings.get('colors.white'))
+				.setColor(Colors.white)
 				.setThumbnail(msg.guild.iconURL(), 50, 50)
 				.setTimestamp();
 
@@ -94,12 +95,12 @@ module.exports = class extends Command {
 	}
 
 	async buildDisplay(caseEmbedArray) {
-		const arrowToLeftEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowToLeft'));
-		const arrowLeftEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowLeft'));
-		const arrowRightEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowRight'));
-		const arrowToRightEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowToRight'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
-		const listEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.list'));
+		const arrowToLeftEmoji = this.client.emojis.cache.get(Emojis.arrowToLeft);
+		const arrowLeftEmoji = this.client.emojis.cache.get(Emojis.arrowLeft);
+		const arrowRightEmoji = this.client.emojis.cache.get(Emojis.arrowRight);
+		const arrowToRightEmoji = this.client.emojis.cache.get(Emojis.arrowToRight);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
+		const listEmoji = this.client.emojis.cache.get(Emojis.list);
 		const display = new RichDisplay()
 			.setEmojis({
 				first: arrowToLeftEmoji.id,

--- a/src/commands/Moderator/purge.js
+++ b/src/commands/Moderator/purge.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { ModCase } = require('../../index');
+const { Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -18,7 +19,7 @@ module.exports = class extends Command {
 	}
 
 	async run(msg, [membername = null, amount, all = null, silent = null]) {
-		if (membername && !msg.member.canMod(membername)) return msg.reject(msg.language.get('COMMAND_PURGE_NO_PERMS', this.client.emojis.cache.get(this.client.settings.get('emoji.reject')), membername));
+		if (membername && !msg.member.canMod(membername)) return msg.reject(msg.language.get('COMMAND_PURGE_NO_PERMS', this.client.emojis.cache.get(Emojis.reject), membername));
 
 		let messages = await msg.channel.messages.fetch({ limit: amount });
 

--- a/src/commands/Moderator/roleinfo.js
+++ b/src/commands/Moderator/roleinfo.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../../lib/util/constants');
 const { momentThreshold, timezoneWithDate } = require('../../lib/util/util');
 const moment = require('moment-timezone');
 
@@ -52,15 +53,15 @@ module.exports = class extends Command {
 			STREAM: msg.language.get('PERMISSIONS_STREAM')
 		};
 		const permissions = Object.entries(rolename.permissions.serialize()).filter(perm => perm[1]).map(([perm]) => perms[perm]).join(', ');
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
 		const status = {
 			true: affirmEmoji,
 			false: rejectEmoji
 		};
 
 		const embed = new MessageEmbed()
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.guild.language.get('NAME'), rolename, true)
 			.addField(msg.guild.language.get('ID'), rolename.id, true)
 			.addField(msg.guild.language.get('MEMBERS'), rolename.members.size, true)

--- a/src/commands/Moderator/serverinfo.js
+++ b/src/commands/Moderator/serverinfo.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../../lib/util/constants');
 const { embedSplitter, momentThreshold, timezoneWithDate } = require('../../lib/util/util');
 const moment = require('moment-timezone');
 
@@ -19,8 +20,8 @@ module.exports = class extends Command {
 	}
 
 	async run(msg) {
-		const partnerEmoji = await this.client.emojis.cache.get(this.client.settings.get('emoji.discordPartner'));
-		const verifiedEmoji = await this.client.emojis.cache.get(this.client.settings.get('emoji.discordVerified'));
+		const partnerEmoji = await this.client.emojis.cache.get(Emojis.discordPartner);
+		const verifiedEmoji = await this.client.emojis.cache.get(Emojis.discordVerified);
 
 		const roles = await msg.guild.roles.cache.filter(role => role.name !== '@everyone').sort().array();
 		const textVoiceChannels = await msg.guild.channels.cache.filter(channel => channel.type === 'text' || channel.type === 'news' || channel.type === 'voice').array();
@@ -34,7 +35,7 @@ module.exports = class extends Command {
 
 		const embed = new MessageEmbed()
 			.setAuthor(msg.guild.name, msg.guild.iconURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.guild.language.get('NAME'), `${msg.guild.partnered ? `${partnerEmoji} ` : msg.guild.verified ? `${verifiedEmoji} ` : ''}${msg.guild.name}`, true)
 			.addField(msg.guild.language.get('ID'), msg.guild.id, true)
 			.addField(msg.guild.language.get('OWNER'), msg.guild.owner, true)

--- a/src/commands/Moderator/support.js
+++ b/src/commands/Moderator/support.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -21,7 +22,7 @@ module.exports = class extends Command {
 			.then(invite => {
 				const embed = new MessageEmbed()
 					.setAuthor(`${msg.guild.name} (#${msg.channel.name})`, msg.guild.iconURL())
-					.setColor(this.client.settings.get('colors.red'))
+					.setColor(Colors.red)
 					.setTitle(msg.guild.language.get('COMMAND_SUPPORT_REQUESTED'))
 					.setDescription(`[${msg.guild.language.get('COMMAND_SUPPORT_JUMPTO')}](${msg.url}) / [${msg.guild.language.get('COMMAND_SUPPORT_JOINSERVER')}](${invite.url})`)
 					.setTimestamp()

--- a/src/commands/Moderator/userinfo.js
+++ b/src/commands/Moderator/userinfo.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Emojis, Colors } = require('../../lib/util/constants');
 const { embedSplitter, momentThreshold, timezoneWithDate } = require('../../lib/util/util');
 const moment = require('moment-timezone');
 
@@ -19,10 +20,10 @@ module.exports = class extends Command {
 	}
 
 	async run(msg, [membername = msg.member]) {
-		const onlineEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.online'));
-		const idleEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.idle'));
-		const dndEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.dnd'));
-		const offlineEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.offline'));
+		const onlineEmoji = this.client.emojis.cache.get(Emojis.online);
+		const idleEmoji = this.client.emojis.cache.get(Emojis.idle);
+		const dndEmoji = this.client.emojis.cache.get(Emojis.dnd);
+		const offlineEmoji = this.client.emojis.cache.get(Emojis.offline);
 		const statuses = {
 			online: `${onlineEmoji} ${msg.guild.language.get('ONLINE')}`,
 			idle: `${idleEmoji} ${msg.guild.language.get('IDLE')}`,
@@ -37,7 +38,7 @@ module.exports = class extends Command {
 		const position = joinPosition.indexOf(membername) + 1;
 
 		const embed = new MessageEmbed()
-			.setColor(!membername.premiumSince ? this.client.settings.get('colors.white') : this.client.settings.get('colors.pink'))
+			.setColor(!membername.premiumSince ? Colors.white : Colors.pink)
 			.addField(msg.guild.language.get('NAME'), `${membername} (${membername.user.tag})`, true)
 			.addField(msg.guild.language.get('ID'), membername.id, true)
 			.addField(msg.language.get('JOIN_POS'), position)

--- a/src/commands/User/discordstatus.js
+++ b/src/commands/User/discordstatus.js
@@ -1,6 +1,7 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
 const fetch = require('node-fetch');
+const { Colors } = require('../../lib/util/constants');
 const { momentThreshold, timezone } = require('../../lib/util/util');
 const moment = require('moment-timezone');
 
@@ -28,7 +29,7 @@ module.exports = class extends Command {
 
 				if (json.incidents.length === 0) {
 					embed.setTitle(msg.language.get('COMMAND_DISCORDSTATUS_ALLOK'))
-						.setColor(this.client.settings.get('colors.green'))
+						.setColor(Colors.green)
 						.setThumbnail('https://cdn.discordapp.com/embed/avatars/2.png')
 						.addField(msg.language.get('COMMAND_DISCORDSTATUS_LASTUPDATE'), timezone(json.page.updated_at, msg.guild));
 				}
@@ -37,7 +38,7 @@ module.exports = class extends Command {
 				if (incident) {
 					embed.setTitle(msg.language.get('COMMAND_DISCORDSTATUS_INCIDENT'))
 						.setDescription(`[${msg.language.get('COMMAND_DISCORDSTATUS_INCIDENT_LINK')}](https://status.discordapp.com/incidents/${incident.incident_id}/)`)
-						.setColor(this.client.settings.get('colors.yellow'))
+						.setColor(Colors.yellow)
 						.setThumbnail('https://cdn.discordapp.com/embed/avatars/3.png')
 						.addField(msg.language.get('COMMAND_DISCORDSTATUS_INCIDENT_TSTAMP'), timezone(incident.created_at, msg.guild))
 						.addField(msg.language.get('COMMAND_DISCORDSTATUS_INCIDENT_UPDATES'), incident.incident_updates[0].body);

--- a/src/commands/User/help.js
+++ b/src/commands/User/help.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2017-2019 dirigeants. All rights reserved. MIT license. Modified by Rasmus Gerdin for use in RTByte.
 const { Command, RichDisplay, util: { isFunction } } = require('klasa');
 const { MessageEmbed, Permissions } = require('discord.js');
+const { Colors, Emojis } = require('../../lib/util/constants');
 
 const PERMISSIONS_RICHDISPLAY = new Permissions([Permissions.FLAGS.MANAGE_MESSAGES, Permissions.FLAGS.ADD_REACTIONS]);
 const time = 1000 * 60 * 3;
@@ -32,7 +33,7 @@ module.exports = class extends Command {
 				.setDescription(isFunction(command.description) ? command.description(msg.language) : command.description)
 				.addField(msg.language.get('COMMAND_HELP_USAGE'), command.usage.fullUsage(msg))
 				.addField(msg.language.get('COMMAND_HELP_EXTENDED'), isFunction(command.extendedHelp) ? command.extendedHelp(msg.language) : command.extendedHelp)
-				.setColor(this.client.settings.get('colors.white'))
+				.setColor(Colors.white)
 				.setThumbnail(this.client.user.displayAvatarURL(), 50, 50)
 				.setTimestamp()
 				.setFooter(msg.language.get('COMMAND_REQUESTED_BY', msg), msg.author.displayAvatarURL());
@@ -48,7 +49,7 @@ module.exports = class extends Command {
 			const loadingEmbed = new MessageEmbed()
 				.setAuthor(msg.language.get('COMMAND_HELP_EMBEDTITLE'), this.client.user.displayAvatarURL())
 				.setDescription(msg.language.get('COMMAND_HELP_LOADING'))
-				.setColor(this.client.settings.get('colors.white'))
+				.setColor(Colors.white)
 				.setThumbnail(this.client.user.displayAvatarURL(), 50, 50)
 				.setTimestamp();
 
@@ -79,12 +80,12 @@ module.exports = class extends Command {
 	}
 
 	async buildDisplay(msg) {
-		const arrowToLeftEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowToLeft'));
-		const arrowLeftEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowLeft'));
-		const arrowRightEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowRight'));
-		const arrowToRightEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowToRight'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
-		const listEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.list'));
+		const arrowToLeftEmoji = this.client.emojis.cache.get(Emojis.arrowToLeft);
+		const arrowLeftEmoji = this.client.emojis.cache.get(Emojis.arrowLeft);
+		const arrowRightEmoji = this.client.emojis.cache.get(Emojis.arrowRight);
+		const arrowToRightEmoji = this.client.emojis.cache.get(Emojis.arrowToRight);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
+		const listEmoji = this.client.emojis.cache.get(Emojis.list);
 		const commands = await this._fetchCommands(msg);
 		const prefix = msg.guild ? msg.guild.settings.get('prefix') : this.client.options.prefix;
 		const display = new RichDisplay()
@@ -102,7 +103,7 @@ module.exports = class extends Command {
 			display.addPage(new MessageEmbed()
 				.setAuthor(msg.language.get('COMMAND_HELP_EMBEDTITLE'), this.client.user.displayAvatarURL())
 				.setTitle(`${category} ${msg.language.get('COMMAND_HELP_COMMANDS')}`)
-				.setColor(this.client.settings.get('colors.white'))
+				.setColor(Colors.white)
 				.setThumbnail(this.client.user.displayAvatarURL(), 50, 50)
 				.setTimestamp()
 				.setDescription(list.map(this.formatCommand.bind(this, msg, prefix, true)).join('\n'))
@@ -115,7 +116,7 @@ module.exports = class extends Command {
 		display.addPage(new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_HELP_EMBEDTITLE'), this.client.user.displayAvatarURL())
 			.setTitle(msg.language.get('CUSTOM_COMMANDS'))
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.setThumbnail(this.client.user.displayAvatarURL(), 50, 50)
 			.setTimestamp()
 			.setDescription(names.map(name => `• **${name}**`))

--- a/src/commands/User/info.js
+++ b/src/commands/User/info.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -15,7 +16,7 @@ module.exports = class extends Command {
 	async run(msg) {
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_INFO_EMBEDTITLE'), this.client.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.setDescription(msg.language.get('COMMAND_INFO_EMBEDDESC'))
 			.addField(msg.language.get('COMMAND_INFO_OURTEAM'), msg.language.get('COMMAND_INFO_TEAMLIST'), true)
 			.addField(msg.language.get('COMMAND_INFO_LINKS'), msg.language.get('COMMAND_INFO_LINKLIST'), true)

--- a/src/commands/User/invite.js
+++ b/src/commands/User/invite.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -14,7 +15,7 @@ module.exports = class extends Command {
 	async run(msg) {
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_INVITE_EMBEDTITLE'), this.client.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.setDescription(msg.language.get('COMMAND_INVITE_EMBEDDESC'))
 			.setThumbnail(this.client.user.displayAvatarURL(), 50, 50)
 			.setTimestamp()

--- a/src/commands/User/joindate.js
+++ b/src/commands/User/joindate.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../../lib/util/constants');
 const { momentThreshold, timezoneWithDate } = require('../../lib/util/util');
 const moment = require('moment-timezone');
 
@@ -24,7 +25,7 @@ module.exports = class extends Command {
 
 		const embed = new MessageEmbed()
 			.setAuthor(membername.user.tag, membername.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.addField(msg.language.get('JOIN_POS'), position)
 			.addField(msg.language.get('JOINED'), timezoneWithDate(membername.joinedTimestamp, msg.guild))
 			.addField(msg.language.get('REGISTERED'), timezoneWithDate(membername.user.createdTimestamp, msg.guild))

--- a/src/commands/User/lyrics.js
+++ b/src/commands/User/lyrics.js
@@ -4,6 +4,7 @@ const { MessageEmbed } = require('discord.js');
 const cheerio = require('cheerio');
 const fetch = require('node-fetch');
 const key = apis.genius;
+const { Colors } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -54,7 +55,7 @@ module.exports = class extends Command {
 		// Build and send the embed
 		const embed = new MessageEmbed()
 			.setAuthor(artist, artistPic)
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.setTitle(songTitle)
 			.setDescription(`[${msg.language.get('COMMAND_LYRICS_LINK')}](${geniusLink})`)
 			.addField(msg.language.get('COMMAND_LYRICS_LYRICS'), lyricsBody)

--- a/src/commands/User/pin.js
+++ b/src/commands/User/pin.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -29,7 +30,7 @@ module.exports = class extends Command {
 
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_PIN_PINNED'), msg.guild.iconURL())
-			.setColor(fetchedPin.member.highestRole ? fetchedPin.member.highestRole.color : this.client.settings.get('colors.white'))
+			.setColor(fetchedPin.member.highestRole ? fetchedPin.member.highestRole.color : Colors.white)
 			.setDescription(`[${msg.guild.language.get('CLICK_TO_VIEW')}](${fetchedPin.url})`)
 			.addField(msg.language.get('BOARD_AUTHOR'), fetchedPin.author, true)
 			.addField(msg.language.get('CHANNEL'), channel, true)

--- a/src/commands/User/quote.js
+++ b/src/commands/User/quote.js
@@ -1,6 +1,7 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
 const moment = require('moment-timezone');
+const { Colors } = require('../../lib/util/constants');
 const { truncate } = require('../../lib/util/util');
 
 module.exports = class extends Command {
@@ -27,7 +28,7 @@ module.exports = class extends Command {
 	async sendQuote(msg, qmsg) {
 		const embed = new MessageEmbed()
 			.setAuthor(qmsg.author.tag, qmsg.author.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.setDescription(`[${msg.language.get('CLICK_TO_VIEW')}](${qmsg.url})`)
 			// eslint-disable-next-line max-len
 			.setFooter(`${moment.tz(qmsg.createdTimestamp, msg.guild ? msg.guild.settings.get('timezone') : 'Etc/Greenwich').format('Do MMMM YYYY, h:mmA zz')} ${msg.guild ? msg.language.get('COMMAND_QUOTE_CHANNEL', qmsg) : msg.language.get('COMMAND_QUOTE_DMS')}`);

--- a/src/commands/User/roles.js
+++ b/src/commands/User/roles.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -22,7 +23,7 @@ module.exports = class extends Command {
 
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_ROLES_SERVER'), this.client.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.setThumbnail(msg.guild.iconURL(), 50, 50)
 			.setTimestamp()
 			.setFooter(msg.language.get('COMMAND_REQUESTED_BY', msg), msg.author.displayAvatarURL());

--- a/src/commands/User/star.js
+++ b/src/commands/User/star.js
@@ -1,5 +1,6 @@
 const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -30,7 +31,7 @@ module.exports = class extends Command {
 
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_STAR_STARRED'), msg.guild.iconURL())
-			.setColor(this.client.settings.get('colors.gold'))
+			.setColor(Colors.gold)
 			.setDescription(`[${msg.guild.language.get('CLICK_TO_VIEW')}](${fetchedStar.url})`)
 			.addField(msg.language.get('BOARD_AUTHOR'), fetchedStar.author, true)
 			.addField(msg.language.get('CHANNEL'), fetchedStar.channel, true)
@@ -85,7 +86,7 @@ module.exports = class extends Command {
 
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('COMMAND_STAR_STARRED'), msg.guild.iconURL())
-			.setColor(this.client.settings.get('colors.gold'))
+			.setColor(Colors.gold)
 			.setDescription(`[${msg.guild.language.get('CLICK_TO_VIEW')}](${fetchedStar.url})`)
 			.addField(msg.language.get('BOARD_AUTHOR'), fetchedStar.author, true)
 			.addField(msg.language.get('CHANNEL'), fetchedStar.channel, true)

--- a/src/commands/User/weather.js
+++ b/src/commands/User/weather.js
@@ -2,6 +2,7 @@ const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
 const fetch = require('node-fetch');
 const { apis } = require('../../config');
+const { Colors } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -68,7 +69,7 @@ module.exports = class extends Command {
 
 						const embed = new MessageEmbed()
 							.setAuthor(geocodeLocation, countryCode ? `https://www.countryflags.io/${countryCode}/flat/64.png` : null)
-							.setColor(this.client.settings.get('colors.white'))
+							.setColor(Colors.white)
 							.setDescription(msg.language.get('COMMAND_WEATHER_LINK', mapsLink, darkskyLink))
 							.addField(msg.language.get('COMMAND_WEATHER_CONDITION'), condition, true)
 							.addField(msg.language.get('COMMAND_WEATHER_TEMPERATURE'), temp, true)

--- a/src/commands/User/wiki.js
+++ b/src/commands/User/wiki.js
@@ -2,6 +2,7 @@ const { Command } = require('klasa');
 const { MessageEmbed } = require('discord.js');
 const fetch = require('node-fetch');
 const nsfw = require('naughty-words/en.json');
+const { Colors } = require('../../lib/util/constants');
 
 module.exports = class extends Command {
 
@@ -24,7 +25,7 @@ module.exports = class extends Command {
 				if (json.type === 'https://mediawiki.org/wiki/HyperSwitch/errors/not_found') return msg.language.get('COMMAND_WIKI_NOTFOUND');
 				const embed = new MessageEmbed()
 					.setAuthor(msg.language.get('COMMAND_WIKI_WIKIPEDIA'), 'https://www.wikipedia.org/portal/wikipedia.org/assets/img/Wikipedia-logo-v2.png')
-					.setColor(this.client.settings.get('colors.white'))
+					.setColor(Colors.white)
 					.setTitle(json.title)
 					.setDescription(`[${msg.language.get('COMMAND_WIKI_LINK')}](${json.content_urls.desktop.page})`)
 					.addField(msg.language.get('COMMAND_WIKI_EMBED_DESC'), `${json.description}.`)

--- a/src/events/autoResponseCreate.js
+++ b/src/events/autoResponseCreate.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -19,7 +20,7 @@ module.exports = class extends Event {
 	async serverLog(msg, autoresponseKeyword, autoresponseContent, executor) {
 		const embed = new MessageEmbed()
 			.setAuthor(autoresponseKeyword, msg.guild.iconURL())
-			.setColor(this.client.settings.get('colors.green'))
+			.setColor(Colors.green)
 			.addField(msg.language.get('GUILD_LOG_AUTORESPONSECREATE_RESPONSE'), autoresponseContent)
 			.setTimestamp()
 			.setFooter(msg.guild.language.get('GUILD_LOG_AUTORESPONSECREATE', executor), executor.displayAvatarURL());

--- a/src/events/autoResponseDelete.js
+++ b/src/events/autoResponseDelete.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -19,7 +20,7 @@ module.exports = class extends Event {
 	async serverLog(msg, autoresponseKeyword, executor) {
 		const embed = new MessageEmbed()
 			.setAuthor(autoresponseKeyword, msg.guild.iconURL())
-			.setColor(this.client.settings.get('colors.red'))
+			.setColor(Colors.red)
 			.setTimestamp()
 			.setFooter(msg.guild.language.get('GUILD_LOG_AUTORESPONSEDELETE', executor), executor.displayAvatarURL());
 

--- a/src/events/autoResponseUpdate.js
+++ b/src/events/autoResponseUpdate.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -19,7 +20,7 @@ module.exports = class extends Event {
 	async serverLog(msg, autoresponseKeyword, autoresponseContent, oldContent, executor) {
 		const embed = new MessageEmbed()
 			.setAuthor(autoresponseKeyword, msg.guild.iconURL())
-			.setColor(this.client.settings.get('colors.blue'))
+			.setColor(Colors.blue)
 			.addField(msg.language.get('GUILD_LOG_BEFORE'), oldContent.content)
 			.addField(msg.language.get('GUILD_LOG_AFTER'), autoresponseContent)
 			.setTimestamp()

--- a/src/events/customCmdCreate.js
+++ b/src/events/customCmdCreate.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -19,7 +20,7 @@ module.exports = class extends Event {
 	async serverLog(msg, cmdName, cmdContent, executor) {
 		const embed = new MessageEmbed()
 			.setAuthor(`${cmdName}`, msg.guild.iconURL())
-			.setColor(this.client.settings.get('colors.green'))
+			.setColor(Colors.green)
 			.addField(msg.language.get('GUILD_LOG_CUSTOMCMDCREATE_RESPONSE'), cmdContent)
 			.setTimestamp()
 			.setFooter(msg.guild.language.get('GUILD_LOG_CUSTOMCMDCREATE', executor), executor.displayAvatarURL());

--- a/src/events/customCmdDelete.js
+++ b/src/events/customCmdDelete.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -19,7 +20,7 @@ module.exports = class extends Event {
 	async serverLog(msg, cmdName, executor) {
 		const embed = new MessageEmbed()
 			.setAuthor(`${cmdName}`, msg.guild.iconURL())
-			.setColor(this.client.settings.get('colors.red'))
+			.setColor(Colors.red)
 			.setTimestamp()
 			.setFooter(msg.guild.language.get('GUILD_LOG_CUSTOMCMDDELETE', executor), executor.displayAvatarURL());
 

--- a/src/events/customCmdUpdate.js
+++ b/src/events/customCmdUpdate.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -19,7 +20,7 @@ module.exports = class extends Event {
 	async serverLog(msg, cmdName, cmdContent, oldCmd, executor) {
 		const embed = new MessageEmbed()
 			.setAuthor(`${cmdName}`, msg.guild.iconURL())
-			.setColor(this.client.settings.get('colors.blue'))
+			.setColor(Colors.blue)
 			.addField(msg.language.get('GUILD_LOG_BEFORE'), oldCmd.content)
 			.addField(msg.language.get('GUILD_LOG_AFTER'), cmdContent)
 			.setTimestamp()

--- a/src/events/guildBoostAdd.js
+++ b/src/events/guildBoostAdd.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -16,7 +17,7 @@ module.exports = class extends Event {
 	async serverLog(member) {
 		const embed = new MessageEmbed()
 			.setAuthor(`${member.displayName} (${member.user.tag}) `, member.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.pink'))
+			.setColor(Colors.pink)
 			.setTimestamp()
 			.setFooter(member.guild.language.get('GUILD_LOG_BOOSTADD'));
 

--- a/src/events/guildBoostTierUpdate.js
+++ b/src/events/guildBoostTierUpdate.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -16,7 +17,7 @@ module.exports = class extends Event {
 	async serverLog(guild) {
 		const nitroEmbed = new MessageEmbed()
 			.setAuthor(guild.name, guild.iconURL())
-			.setColor(this.client.settings.get('colors.pink'))
+			.setColor(Colors.pink)
 			.addField(guild.language.get('GUILD_LOG_BOOSTTIER_TITLES', guild), guild.language.get('GUILD_LOG_BOOSTTIER_DETAILS', guild))
 			.setTimestamp()
 			.setFooter(guild.language.get('GUILD_LOG_BOOSTTIER'));

--- a/src/events/guildBotAdd.js
+++ b/src/events/guildBotAdd.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -14,11 +15,11 @@ module.exports = class extends Event {
 	}
 
 	async serverLog(member, executor) {
-		const botBadgeEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.botBadge'));
+		const botBadgeEmoji = this.client.emojis.cache.get(Emojis.botBadge);
 
 		const embed = new MessageEmbed()
 			.setAuthor(`${member.user.tag} (${member.id})`, member.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.green'))
+			.setColor(Colors.green)
 			.setDescription(botBadgeEmoji)
 			.setTimestamp()
 			.setFooter(member.guild.language.get('GUILD_LOG_GUILDBOTADD', executor), executor.displayAvatarURL());

--- a/src/events/messagePin.js
+++ b/src/events/messagePin.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 const { truncate } = require('../lib/util/util');
 
 module.exports = class extends Event {
@@ -17,7 +18,7 @@ module.exports = class extends Event {
 
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('PINBOARD_PINNED'), msg.guild.iconURL())
-			.setColor(msg.member.highestRole ? msg.member.highestRole.color : this.client.settings.get('colors.white'))
+			.setColor(msg.member.highestRole ? msg.member.highestRole.color : Colors.white)
 			.setDescription(`[${msg.guild.language.get('CLICK_TO_VIEW')}](${msg.url})`)
 			.addField(msg.language.get('BOARD_AUTHOR'), msg.author, true)
 			.addField(msg.language.get('CHANNEL'), msg.channel, true)

--- a/src/events/rtbyteChannelCreate.js
+++ b/src/events/rtbyteChannelCreate.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -26,7 +27,7 @@ module.exports = class extends Event {
 	async serverLog(channel, executor) {
 		const embed = new MessageEmbed()
 			.setAuthor(`#${channel.name}`, channel.guild.iconURL())
-			.setColor(this.client.settings.get('colors.green'))
+			.setColor(Colors.green)
 			.addField(channel.guild.language.get('ID'), channel.id)
 			.setTimestamp()
 			.setFooter(channel.guild.language.get('GUILD_LOG_CHANNELCREATE', executor), executor ? executor.displayAvatarURL() : undefined);

--- a/src/events/rtbyteChannelDelete.js
+++ b/src/events/rtbyteChannelDelete.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -68,7 +69,7 @@ module.exports = class extends Event {
 	async serverLog(channel, executor) {
 		const embed = new MessageEmbed()
 			.setAuthor(`#${channel.name}`, channel.guild.iconURL())
-			.setColor(this.client.settings.get('colors.red'))
+			.setColor(Colors.red)
 			.addField(channel.guild.language.get('ID'), channel.id)
 			.setTimestamp()
 			.setFooter(channel.guild.language.get('GUILD_LOG_CHANNELDELETE', executor), executor ? executor.displayAvatarURL() : undefined);

--- a/src/events/rtbyteChannelUpdate.js
+++ b/src/events/rtbyteChannelUpdate.js
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../lib/util/constants');
 const { momentThreshold } = require('../lib/util/util');
 const moment = require('moment');
 
@@ -29,9 +30,9 @@ module.exports = class extends Event {
 	}
 
 	async serverLog(oldChannel, channel, executor) {
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
-		const arrowRightEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowRight'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
+		const arrowRightEmoji = this.client.emojis.cache.get(Emojis.arrowRight);
 		const status = {
 			true: affirmEmoji,
 			false: rejectEmoji
@@ -39,7 +40,7 @@ module.exports = class extends Event {
 
 		const embed = new MessageEmbed()
 			.setAuthor(`#${channel.name}`, channel.guild.iconURL())
-			.setColor(this.client.settings.get('colors.blue'))
+			.setColor(Colors.blue)
 			.setTimestamp()
 			.setFooter(channel.guild.language.get('GUILD_LOG_CHANNELUPDATE', executor), executor ? executor.displayAvatarURL() : undefined);
 

--- a/src/events/rtbyteEmojiCreate.js
+++ b/src/events/rtbyteEmojiCreate.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -26,7 +27,7 @@ module.exports = class extends Event {
 	async serverLog(emoji, executor) {
 		const embed = new MessageEmbed()
 			.setAuthor(`:${emoji.name}:`, `https://cdn.discordapp.com/emojis/${emoji.id}.${emoji.animated ? 'gif' : 'png'}`)
-			.setColor(this.client.settings.get('colors.green'))
+			.setColor(Colors.green)
 			.setTimestamp()
 			.setFooter(emoji.guild.language.get('GUILD_LOG_EMOJICREATE', executor), executor ? executor.displayAvatarURL() : undefined);
 

--- a/src/events/rtbyteEmojiDelete.js
+++ b/src/events/rtbyteEmojiDelete.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -26,7 +27,7 @@ module.exports = class extends Event {
 	async serverLog(emoji, executor) {
 		const embed = new MessageEmbed()
 			.setAuthor(`:${emoji.name}:`, `https://cdn.discordapp.com/emojis/${emoji.id}.${emoji.animated ? 'gif' : 'png'}`)
-			.setColor(this.client.settings.get('colors.red'))
+			.setColor(Colors.red)
 			.setTimestamp()
 			.setFooter(emoji.guild.language.get('GUILD_LOG_EMOJIDELETE', executor), executor ? executor.displayAvatarURL() : undefined);
 

--- a/src/events/rtbyteEmojiUpdate.js
+++ b/src/events/rtbyteEmojiUpdate.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -24,11 +25,11 @@ module.exports = class extends Event {
 	}
 
 	async serverLog(oldEmoji, emoji, executor) {
-		const arrowRightEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowRight'));
+		const arrowRightEmoji = this.client.emojis.cache.get(Emojis.arrowRight);
 
 		const embed = new MessageEmbed()
 			.setAuthor(`:${emoji.name}:`, `https://cdn.discordapp.com/emojis/${emoji.id}.${emoji.animated ? 'gif' : 'png'}`)
-			.setColor(this.client.settings.get('colors.blue'))
+			.setColor(Colors.blue)
 			.addField(emoji.guild.language.get('NAME_CHANGED'), `${oldEmoji.name} ${arrowRightEmoji} ${emoji.name}`)
 			.setTimestamp()
 			.setFooter(emoji.guild.language.get('GUILD_LOG_EMOJIUPDATE', executor), executor ? executor.displayAvatarURL() : undefined);

--- a/src/events/rtbyteGuildCreate.js
+++ b/src/events/rtbyteGuildCreate.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -20,7 +21,7 @@ module.exports = class extends Event {
 	async globalLog(guild) {
 		const embed = new MessageEmbed()
 			.setAuthor(`${guild.name} (${guild.id})`, guild.iconURL())
-			.setColor(this.client.settings.get('colors.green'))
+			.setColor(Colors.green)
 			.setTimestamp()
 			.setFooter(guild.language.get('GLOBAL_LOG_GUILDCREATE'));
 

--- a/src/events/rtbyteGuildDelete.js
+++ b/src/events/rtbyteGuildDelete.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -16,7 +17,7 @@ module.exports = class extends Event {
 	async globalLog(guild) {
 		const embed = new MessageEmbed()
 			.setAuthor(`${guild.name} (${guild.id})`, guild.iconURL())
-			.setColor(this.client.settings.get('colors.red'))
+			.setColor(Colors.red)
 			.setTimestamp()
 			.setFooter(guild.language.get('GLOBAL_LOG_GUILDDELETE'));
 

--- a/src/events/rtbyteGuildMemberAdd.js
+++ b/src/events/rtbyteGuildMemberAdd.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 const { momentThreshold, timezone } = require('../lib/util/util');
 const moment = require('moment-timezone');
 
@@ -33,7 +34,7 @@ module.exports = class extends Event {
 	async serverLog(member) {
 		const embed = new MessageEmbed()
 			.setAuthor(`${member.user.tag} (${member.id})`, member.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.green'))
+			.setColor(Colors.green)
 			.addField(member.guild.language.get('REGISTERED'), timezone(member.user.createdTimestamp, member.guild))
 			.setTimestamp()
 			.setFooter(member.guild.language.get('GUILD_LOG_GUILDMEMBERADD'));

--- a/src/events/rtbyteGuildMemberRemove.js
+++ b/src/events/rtbyteGuildMemberRemove.js
@@ -1,5 +1,7 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Emojis } = require('../lib/util/constants');
+const { Colors } = require('../lib/util/constants');
 const { momentThreshold, timezone } = require('../lib/util/util');
 const moment = require('moment-timezone');
 
@@ -31,11 +33,11 @@ module.exports = class extends Event {
 	}
 
 	async serverLog(member) {
-		const botBadgeEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.botBadge'));
+		const botBadgeEmoji = this.client.emojis.cache.get(Emojis.botBadge);
 
 		const embed = new MessageEmbed()
 			.setAuthor(`${member.user.tag} (${member.id})`, member.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.red'))
+			.setColor(Colors.red)
 			.addField(member.guild.language.get('JOINED'), timezone(member.joinedTimestamp, member.guild))
 			.setTimestamp()
 			.setFooter(member.guild.language.get('GUILD_LOG_GUILDMEMBERREMOVE', member));

--- a/src/events/rtbyteGuildMemberUpdate.js
+++ b/src/events/rtbyteGuildMemberUpdate.js
@@ -1,6 +1,7 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
 const { ModCase } = require('../index');
+const { Colors, Emojis } = require('../lib/util/constants');
 
 const alternateNames = [
 	'Not having any of this',
@@ -46,7 +47,7 @@ module.exports = class extends Event {
 	}
 
 	async serverLog(oldMember, member, executor) {
-		const arrowRightEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowRight'));
+		const arrowRightEmoji = this.client.emojis.cache.get(Emojis.arrowRight);
 
 		// Filter the user's roles and remove the @everyone role
 		const oldRoleCollection = oldMember.roles.cache.reduce((userRoles, roles) => {
@@ -69,7 +70,7 @@ module.exports = class extends Event {
 		// Base embed
 		const embed = new MessageEmbed()
 			.setAuthor(`${member.displayName} (${member.user.tag}) `, member.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.blue'))
+			.setColor(Colors.blue)
 			.setTimestamp()
 			.setFooter(member.guild.language.get('GUILD_LOG_MEMBERUPDATE', executor), executor ? executor.displayAvatarURL() : undefined);
 

--- a/src/events/rtbyteGuildUnavailable.js
+++ b/src/events/rtbyteGuildUnavailable.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -16,7 +17,7 @@ module.exports = class extends Event {
 	async globalLog(guild) {
 		const embed = new MessageEmbed()
 			.setAuthor(`${guild.name} (${guild.id})`, guild.iconURL())
-			.setColor(this.client.settings.get('colors.yellow'))
+			.setColor(Colors.yellow)
 			.setTimestamp()
 			.setFooter(guild.language.get('GLOBAL_LOG_GUILDUNAVAILABLE'));
 

--- a/src/events/rtbyteGuildUpdate.js
+++ b/src/events/rtbyteGuildUpdate.js
@@ -1,6 +1,8 @@
 /* eslint-disable complexity */
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Emojis } = require('../lib/util/constants');
+const { Colors } = require('../lib/util/constants');
 const { momentThreshold } = require('../lib/util/util');
 const moment = require('moment');
 
@@ -32,9 +34,9 @@ module.exports = class extends Event {
 	}
 
 	async serverLog(oldGuild, guild, executor) {
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
-		const arrowRightEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowRight'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
+		const arrowRightEmoji = this.client.emojis.cache.get(Emojis.arrowRight);
 		const arrayStatus = [
 			rejectEmoji,
 			affirmEmoji
@@ -49,7 +51,7 @@ module.exports = class extends Event {
 		// Base embed
 		const embed = new MessageEmbed()
 			.setAuthor(guild.name, guild.iconURL())
-			.setColor(this.client.settings.get('colors.blue'))
+			.setColor(Colors.blue)
 			.setTimestamp()
 			.setFooter(guild.language.get('GUILD_LOG_GUILDUPDATE', executor), executor ? executor.displayAvatarURL() : undefined);
 
@@ -184,7 +186,7 @@ module.exports = class extends Event {
 	async globalLog(oldGuild, guild) {
 		const embed = new MessageEmbed()
 			.setAuthor(`${guild.name} (${guild.id})`, guild.iconURL())
-			.setColor(this.client.settings.get('colors.blue'))
+			.setColor(Colors.blue)
 			.setTimestamp();
 
 		// Name changed

--- a/src/events/rtbyteInviteCreate.js
+++ b/src/events/rtbyteInviteCreate.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../lib/util/constants');
 const { momentThreshold, timezone } = require('../lib/util/util');
 const moment = require('moment-timezone');
 
@@ -20,12 +21,12 @@ module.exports = class extends Event {
 	}
 
 	async serverLog(invite) {
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
 
 		const embed = new MessageEmbed()
 			.setAuthor(`discord.gg/${invite.code}`, invite.guild.iconURL())
 			.setDescription(invite.url)
-			.setColor(this.client.settings.get('colors.green'))
+			.setColor(Colors.green)
 			.addField(invite.channel.type === 'text' ? invite.guild.language.get('CHANNEL') : invite.guild.language.get('VOICE_CHANNEL'),
 				invite.channel.type === 'text' ? invite.channel : `${invite.channel.name}`, true)
 			.setTimestamp()

--- a/src/events/rtbyteInviteDelete.js
+++ b/src/events/rtbyteInviteDelete.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -30,7 +31,7 @@ module.exports = class extends Event {
 		const embed = new MessageEmbed()
 			.setAuthor(`discord.gg/${invite.code}`, invite.guild.iconURL())
 			.setDescription(invite.url)
-			.setColor(this.client.settings.get('colors.red'))
+			.setColor(Colors.red)
 			.addField(invite.channel.type === 'text' ? invite.guild.language.get('CHANNEL') : invite.guild.language.get('VOICE_CHANNEL'),
 				invite.channel.type === 'text' ? invite.channel : `${invite.channel.name}`, true)
 			.setTimestamp()

--- a/src/events/rtbyteMessageDelete.js
+++ b/src/events/rtbyteMessageDelete.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 const { truncate } = require('../lib/util/util');
 
 module.exports = class extends Event {
@@ -20,7 +21,7 @@ module.exports = class extends Event {
 		const embed = new MessageEmbed()
 			.setAuthor(msg.author.tag, msg.author.displayAvatarURL())
 			.setDescription(msg.channel)
-			.setColor(this.client.settings.get('colors.blue'))
+			.setColor(Colors.blue)
 			.setTimestamp()
 			.setFooter(msg.language.get('GUILD_LOG_MESSAGEDELETE'));
 

--- a/src/events/rtbyteMessageReactionAdd.js
+++ b/src/events/rtbyteMessageReactionAdd.js
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 const { truncate } = require('../lib/util/util');
 
 module.exports = class extends Event {
@@ -22,7 +23,7 @@ module.exports = class extends Event {
 
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('STARBOARD_STARRED'), msg.guild.iconURL())
-			.setColor(this.client.settings.get('colors.gold'))
+			.setColor(Colors.gold)
 			.setDescription(`[${msg.language.get('CLICK_TO_VIEW')}](${msg.url})`)
 			.addField(msg.language.get('BOARD_AUTHOR'), msg.author, true)
 			.addField(msg.language.get('CHANNEL'), msg.channel, true)

--- a/src/events/rtbyteMessageReactionRemove.js
+++ b/src/events/rtbyteMessageReactionRemove.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 const { truncate } = require('../lib/util/util');
 
 module.exports = class extends Event {
@@ -22,7 +23,7 @@ module.exports = class extends Event {
 
 		const embed = new MessageEmbed()
 			.setAuthor(msg.language.get('STARBOARD_STARRED'), msg.guild.iconURL())
-			.setColor(this.client.settings.get('colors.gold'))
+			.setColor(Colors.gold)
 			.setDescription(`[${msg.guild.language.get('CLICK_TO_VIEW')}](${msg.url})`)
 			.addField(msg.language.get('BOARD_AUTHOR'), msg.author, true)
 			.addField(msg.language.get('CHANNEL'), msg.channel, true)

--- a/src/events/rtbyteMessageUpdate.js
+++ b/src/events/rtbyteMessageUpdate.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 const { truncate } = require('../lib/util/util');
 
 module.exports = class extends Event {
@@ -26,7 +27,7 @@ module.exports = class extends Event {
 	async serverLog(old, msg) {
 		const embed = new MessageEmbed()
 			.setAuthor(msg.author.tag, msg.author.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.blue'))
+			.setColor(Colors.blue)
 			.setDescription(`${msg.channel}\n[${msg.language.get('CLICK_TO_VIEW')}](${msg.url})`)
 			.setTimestamp()
 			.setFooter(msg.language.get('GUILD_LOG_MESSAGEUPDATE'));

--- a/src/events/rtbyteReady.js
+++ b/src/events/rtbyteReady.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -50,7 +51,7 @@ module.exports = class extends Event {
 	async botReadyLog() {
 		const embed = new MessageEmbed()
 			.setAuthor(this.client.user.username, this.client.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.yellow'))
+			.setColor(Colors.yellow)
 			.setTimestamp()
 			.setFooter('Bot restarted');
 

--- a/src/events/rtbyteRoleCreate.js
+++ b/src/events/rtbyteRoleCreate.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -26,7 +27,7 @@ module.exports = class extends Event {
 	async serverLog(role, executor) {
 		const embed = new MessageEmbed()
 			.setAuthor(`${role.name}`, role.guild.iconURL())
-			.setColor(this.client.settings.get('colors.green'))
+			.setColor(Colors.green)
 			.addField(role.guild.language.get('ID'), role.id)
 			.addField(role.guild.language.get('GUILD_LOG_ROLECREATE_V_TAG'), role)
 			.setTimestamp()

--- a/src/events/rtbyteRoleDelete.js
+++ b/src/events/rtbyteRoleDelete.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -50,7 +51,7 @@ module.exports = class extends Event {
 	async serverLog(role, executor) {
 		const embed = new MessageEmbed()
 			.setAuthor(`${role.name}`, role.guild.iconURL())
-			.setColor(this.client.settings.get('colors.red'))
+			.setColor(Colors.red)
 			.addField(role.guild.language.get('ID'), role.id, true)
 			.setTimestamp()
 			.setFooter(role.guild.language.get('GUILD_LOG_ROLEDELETE', executor), executor ? executor.displayAvatarURL() : undefined);

--- a/src/events/rtbyteRoleUpdate.js
+++ b/src/events/rtbyteRoleUpdate.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -57,9 +58,9 @@ module.exports = class extends Event {
 	}
 
 	async serverLog(oldRole, role, executor, perms) {
-		const affirmEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
-		const rejectEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
-		const arrowRightEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowRight'));
+		const affirmEmoji = this.client.emojis.cache.get(Emojis.affirm);
+		const rejectEmoji = this.client.emojis.cache.get(Emojis.reject);
+		const arrowRightEmoji = this.client.emojis.cache.get(Emojis.arrowRight);
 		const oldPermissions = Object.entries(oldRole.permissions.serialize()).filter(perm => perm[1]).map(([perm]) => perms[perm]).join(', ');
 		const newPermissions = Object.entries(role.permissions.serialize()).filter(perm => perm[1]).map(([perm]) => perms[perm]).join(', ');
 		const status = {
@@ -69,7 +70,7 @@ module.exports = class extends Event {
 
 		const embed = new MessageEmbed()
 			.setAuthor(`${role.name}`, role.guild.iconURL())
-			.setColor(this.client.settings.get('colors.blue'))
+			.setColor(Colors.blue)
 			.setTimestamp()
 			.setFooter(role.guild.language.get('GUILD_LOG_ROLEUPDATE', executor), executor ? executor.displayAvatarURL() : undefined);
 

--- a/src/events/rtbyteWebhookUpdate.js
+++ b/src/events/rtbyteWebhookUpdate.js
@@ -1,6 +1,7 @@
 /* eslint-disable id-length */
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors, Emojis } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -41,11 +42,11 @@ module.exports = class extends Event {
 	}
 
 	async serverLog(channel, executor, oldWebhook, webhook) {
-		const arrowRightEmoji = this.client.emojis.cache.get(this.client.settings.get('emoji.arrowRight'));
+		const arrowRightEmoji = this.client.emojis.cache.get(Emojis.arrowRight);
 
 		const embed = new MessageEmbed()
 			.setAuthor(webhook.name, webhook.avatar)
-			.setColor(this.client.settings.get('colors.blue'))
+			.setColor(Colors.blue)
 			.setTimestamp()
 			.setFooter(channel.guild.language.get('GUILD_LOG_WEBHOOKUPDATE', executor), executor ? executor.displayAvatarURL() : undefined);
 

--- a/src/events/twitchStreamerLive.js
+++ b/src/events/twitchStreamerLive.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -18,7 +19,7 @@ module.exports = class extends Event {
 	async announceStream(guild, streamer, streamerPic, streamTitle, streamThumbnail, streamViewers, startedAt) {
 		const embed = new MessageEmbed()
 			.setAuthor(streamer, 'https://rtbyte.xyz/img/liveIcon.png')
-			.setColor(this.client.settings.get('colors.purple'))
+			.setColor(Colors.purple)
 			.setTitle(streamTitle)
 			.setDescription(guild.language.get('NOTIFICATION_TWITCH_LINK', streamer))
 			.setThumbnail(streamerPic)

--- a/src/events/webhookCreate.js
+++ b/src/events/webhookCreate.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -18,7 +19,7 @@ module.exports = class extends Event {
 	async serverLog(channel, executor, webhook) {
 		const embed = new MessageEmbed()
 			.setAuthor(webhook.name, webhook.avatar)
-			.setColor(this.client.settings.get('colors.green'))
+			.setColor(Colors.green)
 			.addField(channel.guild.language.get('CHANNEL'), webhook.channel)
 			.setTimestamp()
 			.setFooter(channel.guild.language.get('GUILD_LOG_WEBHOOKCREATE', executor), executor ? executor.displayAvatarURL() : undefined);

--- a/src/events/webhookDelete.js
+++ b/src/events/webhookDelete.js
@@ -1,5 +1,6 @@
 const { Event } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Event {
 
@@ -18,7 +19,7 @@ module.exports = class extends Event {
 	async serverLog(channel, executor, webhook) {
 		const embed = new MessageEmbed()
 			.setAuthor(webhook.name, webhook.avatar)
-			.setColor(this.client.settings.get('colors.red'))
+			.setColor(Colors.red)
 			.addField(channel.guild.language.get('CHANNEL'), webhook.channel)
 			.setTimestamp()
 			.setFooter(channel.guild.language.get('GUILD_LOG_WEBHOOKDELETE', executor), executor ? executor.displayAvatarURL() : undefined);

--- a/src/extendables/KlasaGuild/fn_KlasaGuild#rtbyteInit.js
+++ b/src/extendables/KlasaGuild/fn_KlasaGuild#rtbyteInit.js
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
 const { Extendable, KlasaGuild } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../../lib/util/constants');
 
 module.exports = class extends Extendable {
 
@@ -147,7 +148,7 @@ module.exports = class extends Extendable {
 		// Building server owner message embed
 		const embed = new MessageEmbed()
 			.setAuthor(this.language.get('INIT_TITLE'), this.client.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.setImage('https://rtbyte.xyz/img/og-img.jpg')
 			.setTimestamp();
 

--- a/src/extendables/KlasaGuild/fn_KlasaGuild#rtbyteInit.js
+++ b/src/extendables/KlasaGuild/fn_KlasaGuild#rtbyteInit.js
@@ -101,41 +101,6 @@ module.exports = class extends Extendable {
 					await this.client.settings.update('guilds.controlGuild', this.id, this);
 					await this.client.settings.update('channels.globalLog', globalLogChannel.id, this);
 
-					// Adding and initializing the emojis for the bot to use
-					const affirmEmoji = await this.emojis.create('./assets/img/emoji/affirm.png', 'affirm', { reason: `${this.client.user.username} initialization: creating affirm emoji` });
-					const rejectEmoji = await this.emojis.create('./assets/img/emoji/reject.png', 'reject', { reason: `${this.client.user.username} initialization: creating reject emoji` });
-					const arrowLeftEmoji = await this.emojis.create('./assets/img/emoji/arrowLeft.png', 'arrow_left', { reason: `${this.client.user.username} initialization: creating arrowLeft emoji` });
-					// eslint-disable-next-line max-len
-					const arrowToLeftEmoji = await this.emojis.create('./assets/img/emoji/arrowToLeft.png', 'arrow_to_left', { reason: `${this.client.user.username} initialization: creating arrowToLeft emoji` });
-					const arrowRightEmoji = await this.emojis.create('./assets/img/emoji/arrowRight.png', 'arrow_right', { reason: `${this.client.user.username} initialization: creating arrowRight emoji` });
-					// eslint-disable-next-line max-len
-					const arrowToRightEmoji = await this.emojis.create('./assets/img/emoji/arrowToRight.png', 'arrow_to_right', { reason: `${this.client.user.username} initialization: creating arrowToRight emoji` });
-					const infoEmoji = await this.emojis.create('./assets/img/emoji/info.png', 'info', { reason: `${this.client.user.username} initialization: creating info emoji` });
-					const listEmoji = await this.emojis.create('./assets/img/emoji/list.png', 'list', { reason: `${this.client.user.username} initialization: creating list emoji` });
-					const onlineEmoji = await this.emojis.create('./assets/img/emoji/online.png', 'online', { reason: `${this.client.user.username} initialization: creating online emoji` });
-					const idleEmoji = await this.emojis.create('./assets/img/emoji/idle.png', 'idle', { reason: `${this.client.user.username} initialization: creating idle emoji` });
-					const dndEmoji = await this.emojis.create('./assets/img/emoji/dnd.png', 'dnd', { reason: `${this.client.user.username} initialization: creating dnd emoji` });
-					const offlineEmoji = await this.emojis.create('./assets/img/emoji/offline.png', 'offline', { reason: `${this.client.user.username} initialization: creating offline emoji` });
-					const botBadgeEmoji = await this.emojis.create('./assets/img/emoji/botBadge.png', 'bot_badge', { reason: `${this.client.user.username} initialization: creating bot badge emoji` });
-					// eslint-disable-next-line max-len
-					const partnerEmoji = await this.emojis.create('./assets/img/emoji/partner.png', 'discord_partner', { reason: `${this.client.user.username} initialization: creating Discord partner emoji` });
-					// eslint-disable-next-line max-len
-					const verifiedEmoji = await this.emojis.create('./assets/img/emoji/verified.png', 'discord_verified', { reason: `${this.client.user.username} initialization: creating Discord verified emoji` });
-					await this.client.settings.update('emoji.affirm', affirmEmoji.id, this);
-					await this.client.settings.update('emoji.reject', rejectEmoji.id, this);
-					await this.client.settings.update('emoji.arrowLeft', arrowLeftEmoji.id, this);
-					await this.client.settings.update('emoji.arrowToLeft', arrowToLeftEmoji.id, this);
-					await this.client.settings.update('emoji.arrowRight', arrowRightEmoji.id, this);
-					await this.client.settings.update('emoji.arrowToRight', arrowToRightEmoji.id, this);
-					await this.client.settings.update('emoji.info', infoEmoji.id, this);
-					await this.client.settings.update('emoji.list', listEmoji.id, this);
-					await this.client.settings.update('emoji.online', onlineEmoji.id, this);
-					await this.client.settings.update('emoji.idle', idleEmoji.id, this);
-					await this.client.settings.update('emoji.dnd', dndEmoji.id, this);
-					await this.client.settings.update('emoji.offline', offlineEmoji.id, this);
-					await this.client.settings.update('emoji.botBadge', botBadgeEmoji.id, this);
-					await this.client.settings.update('emoji.discordPartner', partnerEmoji.id, this);
-					await this.client.settings.update('emoji.discordVerified', verifiedEmoji.id, this);
 					await this.client.settings.sync(true);
 				}
 			}

--- a/src/extendables/KlasaMessage/fn_KlasaMessage#affirm.js
+++ b/src/extendables/KlasaMessage/fn_KlasaMessage#affirm.js
@@ -1,4 +1,5 @@
 const { Extendable, KlasaMessage } = require('klasa');
+const { Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Extendable {
 
@@ -7,7 +8,7 @@ module.exports = class extends Extendable {
 	}
 
 	async affirm(message = null, messageOptions = {}) {
-		const affirmEmoji = await this.client.emojis.cache.get(this.client.settings.get('emoji.affirm'));
+		const affirmEmoji = await this.client.emojis.cache.get(Emojis.affirm);
 		await this.react(affirmEmoji);
 		return message ? this.sendMessage(`${this.author}\n${affirmEmoji} ${message}`, messageOptions) : this;
 	}

--- a/src/extendables/KlasaMessage/fn_KlasaMessage#arrowLeft.js
+++ b/src/extendables/KlasaMessage/fn_KlasaMessage#arrowLeft.js
@@ -1,4 +1,5 @@
 const { Extendable, KlasaMessage } = require('klasa');
+const { Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Extendable {
 
@@ -7,7 +8,7 @@ module.exports = class extends Extendable {
 	}
 
 	async arrowLeft(message = null, messageOptions = {}) {
-		const arrowLeftEmoji = await this.client.emojis.cache.get(this.client.settings.get('emoji.arrowLeft'));
+		const arrowLeftEmoji = await this.client.emojis.cache.get(Emojis.arrowLeft);
 		await this.react(arrowLeftEmoji);
 		return message ? this.sendMessage(`${this.author}\n${arrowLeftEmoji} ${message}`, messageOptions) : this;
 	}

--- a/src/extendables/KlasaMessage/fn_KlasaMessage#arrowRight.js
+++ b/src/extendables/KlasaMessage/fn_KlasaMessage#arrowRight.js
@@ -1,4 +1,5 @@
 const { Extendable, KlasaMessage } = require('klasa');
+const { Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Extendable {
 
@@ -7,7 +8,7 @@ module.exports = class extends Extendable {
 	}
 
 	async arrowRight(message = null, messageOptions = {}) {
-		const arrowRightEmoji = await this.client.emojis.cache.get(this.client.settings.get('emoji.arrowRight'));
+		const arrowRightEmoji = await this.client.emojis.cache.get(Emojis.arrowRight);
 		await this.react(arrowRightEmoji);
 		return message ? this.sendMessage(`${this.author}\n${arrowRightEmoji} ${message}`, messageOptions) : this;
 	}

--- a/src/extendables/KlasaMessage/fn_KlasaMessage#arrowToLeft.js
+++ b/src/extendables/KlasaMessage/fn_KlasaMessage#arrowToLeft.js
@@ -1,4 +1,5 @@
 const { Extendable, KlasaMessage } = require('klasa');
+const { Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Extendable {
 
@@ -7,7 +8,7 @@ module.exports = class extends Extendable {
 	}
 
 	async arrowToLeft(message = null, messageOptions = {}) {
-		const arrowToLeftEmoji = await this.client.emojis.cache.get(this.client.settings.get('emoji.arrowToLeft'));
+		const arrowToLeftEmoji = await this.client.emojis.cache.get(Emojis.arrowToLeft);
 		await this.react(arrowToLeftEmoji);
 		return message ? this.sendMessage(`${this.author}\n${arrowToLeftEmoji} ${message}`, messageOptions) : this;
 	}

--- a/src/extendables/KlasaMessage/fn_KlasaMessage#arrowToRight.js
+++ b/src/extendables/KlasaMessage/fn_KlasaMessage#arrowToRight.js
@@ -1,4 +1,5 @@
 const { Extendable, KlasaMessage } = require('klasa');
+const { Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Extendable {
 
@@ -7,7 +8,7 @@ module.exports = class extends Extendable {
 	}
 
 	async arrowToRight(message = null, messageOptions = {}) {
-		const arrowToRightEmoji = await this.client.emojis.cache.get(this.client.settings.get('emoji.arrowToRight'));
+		const arrowToRightEmoji = await this.client.emojis.cache.get(Emojis.arrowToRight);
 		await this.react(arrowToRightEmoji);
 		return message ? this.sendMessage(`${this.author}\n${arrowToRightEmoji} ${message}`, messageOptions) : this;
 	}

--- a/src/extendables/KlasaMessage/fn_KlasaMessage#info.js
+++ b/src/extendables/KlasaMessage/fn_KlasaMessage#info.js
@@ -1,4 +1,5 @@
 const { Extendable, KlasaMessage } = require('klasa');
+const { Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Extendable {
 
@@ -7,7 +8,7 @@ module.exports = class extends Extendable {
 	}
 
 	async info(message = null, messageOptions = {}) {
-		const infoEmoji = await this.client.emojis.cache.get(this.client.settings.get('emoji.info'));
+		const infoEmoji = await this.client.emojis.cache.get(Emojis.info);
 		await this.react(infoEmoji);
 		return message ? this.sendMessage(`${this.author}\n${infoEmoji} ${message}`, messageOptions) : this;
 	}

--- a/src/extendables/KlasaMessage/fn_KlasaMessage#list.js
+++ b/src/extendables/KlasaMessage/fn_KlasaMessage#list.js
@@ -1,4 +1,5 @@
 const { Extendable, KlasaMessage } = require('klasa');
+const { Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Extendable {
 
@@ -7,7 +8,7 @@ module.exports = class extends Extendable {
 	}
 
 	async list(message = null, messageOptions = {}) {
-		const listEmoji = await this.client.emojis.cache.get(this.client.settings.get('emoji.list'));
+		const listEmoji = await this.client.emojis.cache.get(Emojis.list);
 		await this.react(listEmoji);
 		return message ? this.sendMessage(`${this.author}\n${listEmoji} ${message}`, messageOptions) : this;
 	}

--- a/src/extendables/KlasaMessage/fn_KlasaMessage#reject.js
+++ b/src/extendables/KlasaMessage/fn_KlasaMessage#reject.js
@@ -1,4 +1,5 @@
 const { Extendable, KlasaMessage } = require('klasa');
+const { Emojis } = require('../../lib/util/constants');
 
 module.exports = class extends Extendable {
 
@@ -7,7 +8,7 @@ module.exports = class extends Extendable {
 	}
 
 	async reject(message = null, messageOptions = {}) {
-		const rejectEmoji = await this.client.emojis.cache.get(this.client.settings.get('emoji.reject'));
+		const rejectEmoji = await this.client.emojis.cache.get(Emojis.reject);
 		await this.react(rejectEmoji);
 		return message ? this.sendMessage(`${this.author}\n${rejectEmoji} ${message}`, messageOptions) : this;
 	}

--- a/src/finalizers/devCommandLog.js
+++ b/src/finalizers/devCommandLog.js
@@ -1,5 +1,6 @@
 const { Finalizer } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Finalizer {
 
@@ -22,7 +23,7 @@ module.exports = class extends Finalizer {
 	async commandRunLog(message, runTime, logChannel) {
 		const embed = new MessageEmbed()
 			.setAuthor(`${message.guild.name} (#${message.channel.name})`, message.guild.iconURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.setTitle(message.guild.language.get('GLOBAL_LOG_COMMANDRUN'))
 			.setDescription(`[${message.guild.language.get('CLICK_TO_VIEW')}](${message.url})`)
 			.addField('Message', message.content)
@@ -39,7 +40,7 @@ module.exports = class extends Finalizer {
 	async dmCommandLog(message, runTime, logChannel) {
 		const embed = new MessageEmbed()
 			.setAuthor(`${message.author.tag} (${message.author.id})`, message.author.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.setTitle(message.language.get('GLOBAL_LOG_COMMANDRUN_DM'))
 			.addField('Message', message.content)
 			.addField('Runtime', runTime)

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,5 @@ module.exports = {
 	RTByteClient: require('./lib/RTByteClient'),
 	SentryClient: require('./lib/SentryClient'),
 	ModCase: require('./lib/structures/ModCase'),
-	ModEmbed: require('./lib/structures/ModEmbed'),
-	Util: require('./lib/util/util')
+	ModEmbed: require('./lib/structures/ModEmbed')
 };

--- a/src/lib/structures/ModEmbed.js
+++ b/src/lib/structures/ModEmbed.js
@@ -1,4 +1,5 @@
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../util/constants');
 const { embedSplitter } = require('../util/Util');
 
 class ModEmbed extends MessageEmbed {
@@ -18,22 +19,22 @@ class ModEmbed extends MessageEmbed {
 		if (this.modCase.user) this.setThumbnail(this.modCase.user.displayAvatarURL());
 		/* eslint-disable indent */
 			this.setColor(
-				this.modCase.type === 'ban' ? this.modCase.client.settings.get('colors.red') :
-				this.modCase.type === 'unban' ? this.modCase.client.settings.get('colors.yellow') :
-				this.modCase.type === 'kick' ? this.modCase.client.settings.get('colors.red') :
-				this.modCase.type === 'mute' ? this.modCase.client.settings.get('colors.red') :
-				this.modCase.type === 'unmute' ? this.modCase.client.settings.get('colors.yellow') :
-				this.modCase.type === 'purge' ? this.modCase.client.settings.get('colors.red') :
-				this.modCase.type === 'softban' ? this.modCase.client.settings.get('colors.red') :
-				this.modCase.type === 'vcban' ? this.modCase.client.settings.get('colors.red') :
-				this.modCase.type === 'vcunban' ? this.modCase.client.settings.get('colors.yellow') :
-				this.modCase.type === 'vckick' ? this.modCase.client.settings.get('colors.red') :
-				this.modCase.type === 'antiInvite' ? this.modCase.client.settings.get('colors.red') :
-				this.modCase.type === 'mentionSpam' ? this.modCase.client.settings.get('colors.red') :
-				this.modCase.type === 'blacklistedWord' ? this.modCase.client.settings.get('colors.red') :
-				this.modCase.type === 'blacklistedNickname' ? this.modCase.client.settings.get('colors.red') :
-				this.modCase.type === 'warn' ? this.modCase.client.settings.get('colors.yellow') :
-				this.modCase.client.settings.get('colors.blue'));
+				this.modCase.type === 'ban' ? Colors.red :
+				this.modCase.type === 'unban' ? Colors.yellow :
+				this.modCase.type === 'kick' ? Colors.red :
+				this.modCase.type === 'mute' ? Colors.red :
+				this.modCase.type === 'unmute' ? Colors.yellow :
+				this.modCase.type === 'purge' ? Colors.red :
+				this.modCase.type === 'softban' ? Colors.red :
+				this.modCase.type === 'vcban' ? Colors.red :
+				this.modCase.type === 'vcunban' ? Colors.yellow :
+				this.modCase.type === 'vckick' ? Colors.red :
+				this.modCase.type === 'antiInvite' ? Colors.red :
+				this.modCase.type === 'mentionSpam' ? Colors.red :
+				this.modCase.type === 'blacklistedWord' ? Colors.red :
+				this.modCase.type === 'blacklistedNickname' ? Colors.red :
+				this.modCase.type === 'warn' ? Colors.yellow :
+				Colors.blue);
 			/* eslint-enable indent */
 		this.setTimestamp(this.modCase.timestamp);
 		this.setFooter(this.modCase.guild.language.get('MODERATION_LOG_EVENTLOGGED'), this.modCase.client.user.displayAvatarURL());

--- a/src/lib/structures/schemas/defaultClientSchema.js
+++ b/src/lib/structures/schemas/defaultClientSchema.js
@@ -3,51 +3,13 @@ const { KlasaClient } = require('klasa');
 module.exports = KlasaClient.defaultClientSchema
 	.add('guilds', folder => folder.add('controlGuild', 'guild'))
 	.add('channels', folder => folder.add('globalLog', 'textchannel'))
-	.add('emoji', folder => folder
-		.add('affirm', 'string')
-		.add('reject', 'string')
-		.add('arrowLeft', 'string')
-		.add('arrowToLeft', 'string')
-		.add('arrowRight', 'string')
-		.add('arrowToRight', 'string')
-		.add('info', 'string')
-		.add('list', 'string')
-		.add('online', 'string')
-		.add('idle', 'string')
-		.add('dnd', 'string')
-		.add('offline', 'string')
-		.add('botBadge', 'string')
-		.add('discordPartner', 'string')
-		.add('discordVerified', 'string'))
 	.add('logs', folder => folder
 		.add('botReady', 'boolean', { default: true })
 		.add('commandRun', 'boolean', { default: true })
-		.add('commandError', 'boolean', { default: true })
-		.add('eventError', 'boolean', { default: true })
-		.add('finalizerError', 'boolean', { default: true })
-		.add('monitorError', 'boolean', { default: true })
-		.add('taskError', 'boolean', { default: true })
 		.add('guildCreate', 'boolean', { default: true })
 		.add('guildDelete', 'boolean', { default: true })
 		.add('guildUpdate', 'boolean', { default: true })
 		.add('guildUnavailable', 'boolean', { default: true }))
-	.add('colors', folder => folder
-	// Informative, neutral
-		.add('white', 'string', { default: '#FEFEFE' })
-	// Users leaving, actions against users, severe warnings, errors
-		.add('red', 'string', { default: '#FF4B4B' })
-	// Users joining, stuff being added
-		.add('green', 'string', { default: '#4BFF4B' })
-	// Punishments being taken away, warnings, bot restarts
-		.add('yellow', 'string', { default: '#FFFF4B' })
-	// Message deletions and updates, changes
-		.add('blue', 'string', { default: '#4B4BFF' })
-	// Nitro Boosts
-		.add('pink', 'string', { default: '#F47FFF' })
-	// Starboard
-		.add('gold', 'string', { default: '#DAA520' })
-	// Twitch
-		.add('purple', 'string', { default: '#9046FF' }))
 	.add('moderation', folder => folder
 		.add('cases', 'any', { array: true }))
 	.add('twitchOauthBearer', 'string');

--- a/src/lib/util/constants.js
+++ b/src/lib/util/constants.js
@@ -1,0 +1,28 @@
+exports.Colors = {
+	white: '#FEFEFE',
+	red: '#FF4B4B',
+	green: '#4BFF4B',
+	yellow: '#FFFF4B',
+	blue: '#4B4BFF',
+	pink: '#F47FFF',
+	gold: '#DAA520',
+	purple: '#9046FF'
+};
+
+exports.Emojis = {
+	affirm: '557276640124600350',
+	reject: '557276639923404810',
+	arrowLeft: '557276639726141451',
+	arrowToLeft: '557276641819230259',
+	arrowRight: '557276639399116820',
+	arrowToRight: '557276640141508608',
+	info: '557276638837080076',
+	list: '557276640657408017',
+	online: '548280346370637825',
+	idle: '548280349310976001',
+	dnd: '548280353278656528',
+	offline: '548280355438985216',
+	botBadge: '703369019981561877',
+	discordPartner: '726810056577777754',
+	discordVerified: '726810056087044189'
+};

--- a/src/tasks/monthlyReboot.js
+++ b/src/tasks/monthlyReboot.js
@@ -1,5 +1,6 @@
 const { Task } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Task {
 
@@ -12,7 +13,7 @@ module.exports = class extends Task {
 	async weeklyRebootLog() {
 		const embed = new MessageEmbed()
 			.setAuthor(this.client.user.username, this.client.user.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.yellow'))
+			.setColor(Colors.yellow)
 			.setTimestamp()
 			.setFooter('Performing monthly reboot...');
 

--- a/src/tasks/reminder.js
+++ b/src/tasks/reminder.js
@@ -1,5 +1,6 @@
 const { Task } = require('klasa');
 const { MessageEmbed } = require('discord.js');
+const { Colors } = require('../lib/util/constants');
 
 module.exports = class extends Task {
 
@@ -10,7 +11,7 @@ module.exports = class extends Task {
 
 		const embed = new MessageEmbed()
 			.setAuthor(guild ? member.user.tag : member.tag, guild ? member.user.displayAvatarURL() : member.displayAvatarURL())
-			.setColor(this.client.settings.get('colors.white'))
+			.setColor(Colors.white)
 			.setDescription(reminderMsg)
 			.setTimestamp(timestamp)
 			.setFooter(`Reminder set in ${guild ? channel.name : 'DMs'}${guild ? ` on the ${guild.name} Discord` : ''}`);


### PR DESCRIPTION
This PR introduces changes around how constants are stored for the bot. We've previously been using Klasa's client settings gateway. Due to bugs in this system, this has however lead to minor data loss (fixed by manual data entry). 

This PR solves this by moving the emoji and color constants to a constants file (stored in `/lib/util/constants`). I've also removed the automatic creation of the emojis due to this change.

This can be extended to other properties as well, and I will likely be doing so over the next few days.